### PR TITLE
RGB and Depth now viewable

### DIFF
--- a/examples/run.py
+++ b/examples/run.py
@@ -1,0 +1,17 @@
+import pyfreenect2
+import cv2
+import scipy.misc
+import signal
+
+
+pf = pyfreenect2.PyFreeNect2()
+
+cv2.startWindowThread()
+cv2.namedWindow("RGB")
+while True:
+    extracted_frame = pf.get_new_frame()
+    resized = scipy.misc.imresize(extracted_frame.RGB, size = 0.5)
+    cv2.imshow("RGB", resized)
+    cv2.waitKey(20)
+print "done"
+    

--- a/examples/run.py
+++ b/examples/run.py
@@ -9,8 +9,8 @@ pf = pyfreenect2.PyFreeNect2()
 cv2.startWindowThread()
 cv2.namedWindow("RGB")
 while True:
-    extracted_frame = pf.get_new_frame()
-    resized = scipy.misc.imresize(extracted_frame.RGB, size = 0.5)
+    extracted_frame = pf.get_new_frame(get_BGR = True)
+    resized = scipy.misc.imresize(extracted_frame.BGR, size = 0.5)
     cv2.imshow("RGB", resized)
     cv2.waitKey(20)
 print "done"

--- a/examples/run.py
+++ b/examples/run.py
@@ -2,7 +2,7 @@ import pyfreenect2
 import cv2
 import scipy.misc
 import signal
-
+import numpy as np
 
 pf = pyfreenect2.PyFreeNect2()
 

--- a/pyfreenect2.cpp
+++ b/pyfreenect2.cpp
@@ -34,11 +34,10 @@ static PyMethodDef pyfreenect2Methods[] = {
 
 PyMODINIT_FUNC init_pyfreenect2() {
 
+  /// enables debug of libfreenect2
+  ///libfreenect2::setGlobalLogger(libfreenect2::createConsoleLogger(libfreenect2::Logger::Debug));
 
-	libfreenect2::setGlobalLogger(libfreenect2::createConsoleLogger(libfreenect2::Logger::Debug));
-
-	import_array();
-	Py_InitModule("_pyfreenect2", pyfreenect2Methods);
-	import_array();
-
+  import_array();
+  Py_InitModule("_pyfreenect2", pyfreenect2Methods);
+  import_array();
 }

--- a/pyfreenect2.cpp
+++ b/pyfreenect2.cpp
@@ -27,6 +27,7 @@ static PyMethodDef pyfreenect2Methods[] = {
 	{ "Frame_getHeight", py_Frame_getHeight, METH_VARARGS, NULL },
 	{ "Frame_getWidth", py_Frame_getWidth, METH_VARARGS, NULL },
 	{ "Frame_getData", py_Frame_getData, METH_VARARGS, NULL },
+	{ "Frame_getDepthData", py_Frame_getDepthData, METH_VARARGS, NULL },
 	// Sentinel
 	{ NULL, NULL, 0, NULL}
 };

--- a/pyfreenect2.cpp
+++ b/pyfreenect2.cpp
@@ -1,4 +1,5 @@
 #include "pyfreenect2.hpp"
+#include <iostream>
 
 static PyMethodDef pyfreenect2Methods[] = {
 	// Freenect2
@@ -31,6 +32,12 @@ static PyMethodDef pyfreenect2Methods[] = {
 };
 
 PyMODINIT_FUNC init_pyfreenect2() {
+
+
+	libfreenect2::setGlobalLogger(libfreenect2::createConsoleLogger(libfreenect2::Logger::Debug));
+
+	import_array();
 	Py_InitModule("_pyfreenect2", pyfreenect2Methods);
 	import_array();
+
 }

--- a/pyfreenect2.hpp
+++ b/pyfreenect2.hpp
@@ -3,6 +3,7 @@
 #include <Python.h>
 #include <string>
 #include <libfreenect2/libfreenect2.hpp>
+#include <libfreenect2/logger.h>
 #include <libfreenect2/frame_listener_impl.h>
 #include <libfreenect2/registration.h>
 #include <numpy/arrayobject.h>

--- a/pyfreenect2.hpp
+++ b/pyfreenect2.hpp
@@ -64,6 +64,7 @@ void py_Frame_destroy(PyObject *object);
 PyObject *py_Frame_getHeight(PyObject *self, PyObject *args);
 PyObject *py_Frame_getWidth(PyObject *self, PyObject *args);
 PyObject *py_Frame_getData(PyObject *self, PyObject *args);
+PyObject *py_Frame_getDepthData(PyObject *self, PyObject *args);
 
 ////////////////////////////////////////////////////////////////////////////////
 //                                Registration                                //

--- a/pyfreenect2.py
+++ b/pyfreenect2.py
@@ -36,6 +36,7 @@ class Freenect2Device:
 		if not isinstance(listener, SyncMultiFrameListener):
 			raise TypeError("Argument to Freenect2Device.setColorFrameListener must be of type Freenect2Device.SyncMultiFrameListener")
 		else:
+                        print "listener capsule : " , listener._capsule
 			_pyfreenect2.Freenect2Device_setColorFrameListener(self._capsule, listener._capsule)
 	def setIrAndDepthFrameListener(self, listener):
 		if not isinstance(listener, SyncMultiFrameListener):
@@ -68,14 +69,12 @@ class SyncMultiFrameListener:
 	def waitForNewFrame(self):
 		return FrameMap(_pyfreenect2.SyncMultiFrameListener_waitForNewFrame(self._capsule))
 
-
 ################################################################################
 #                                   FrameMap                                   #
 ################################################################################
 
 class FrameMap:
 	def __init__(self, capsule):
-		print "DEBUG: FrameMap capsule type = %s" % type(capsule)
 		self._capsule = capsule
 	def getFrame(self, frame_type):
 		if not frame_type in (1, 2, 4):

--- a/pyfreenect2.py
+++ b/pyfreenect2.py
@@ -1,4 +1,5 @@
 import _pyfreenect2
+import numpy as np
 from collections import namedtuple
 
 ExtractedKinectFrame = namedtuple("ExtractedKinectFrame",
@@ -54,6 +55,7 @@ class DeveloperIsALazyBastardError(Exception):
 
 def numberOfDevices():
 	return _pyfreenect2.numberOfDevices()
+
 def getDefaultDeviceSerialNumber():
 	if numberOfDevices() == 0:
 		raise PyFreenect2Error("Could not find a Kinect v2")
@@ -139,10 +141,12 @@ class Frame:
 		return _pyfreenect2.Frame_getWidth(self._capsule)
 	def getRGBData(self):
                 ## todo fix copy necessity (reference counting to frame)
-		return _pyfreenect2.Frame_getData(self._capsule).copy()
+                ## todo fix fliplr necessity
+		return np.fliplr(_pyfreenect2.Frame_getData(self._capsule).copy())
 	def getDepthData(self):
                 ## todo fix copy necessity (reference counting to frame)                
-		return _pyfreenect2.Frame_getDepthData(self._capsule).copy()
+                ## todo fix fliplr necessity
+		return np.fliplr(_pyfreenect2.Frame_getDepthData(self._capsule).copy())
 
 ################################################################################
 #                                 Registration                                 #

--- a/pyfreenect2.py
+++ b/pyfreenect2.py
@@ -97,8 +97,12 @@ class Frame:
 		return _pyfreenect2.Frame_getHeight(self._capsule)
 	def getWidth(self):
 		return _pyfreenect2.Frame_getWidth(self._capsule)
-	def getData(self):
+	def getRGBData(self):
+                print "getting data"
 		return _pyfreenect2.Frame_getData(self._capsule)
+	def getDepthData(self):
+                print "getting data"
+		return _pyfreenect2.Frame_getDepthData(self._capsule)
 
 ################################################################################
 #                                 Registration                                 #

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,0 +1,2 @@
+sudo rm /usr/local/lib/python2.7/dist-packages/pyfreenect2-0.0.0-py2.7-linux-x86_64.egg
+sudo python2 setup.py install

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ libfreenect2_module = Extension("_pyfreenect2",
 		"src/Freenect2Device.cpp",
 		"src/Registration.cpp",
 		"src/SyncMultiFrameListener.cpp"],
+        extra_compile_args = ["-fpermissive"],
 	include_dirs=[numpy.get_include()],
 	define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")])
 

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -55,7 +55,6 @@ PyObject *py_Frame_getDepthData(PyObject *self, PyObject *args)
 
 	import_array();
 
-	std::cout << "bpp: " << frame->bytes_per_pixel << std::endl;
 	PyArrayObject *array = (PyArrayObject*) PyArray_SimpleNewFromData(3, 
 									  dims, 
 									  NPY_UINT8,

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -28,16 +28,37 @@ PyObject *py_Frame_getData(PyObject *self, PyObject *args) {
 	if(!PyArg_ParseTuple(args, "O", &frameCapsule))
 		return NULL;
 	Frame *frame = (Frame*) PyCapsule_GetPointer(frameCapsule, "Frame");
+
+	// frames are apparently 4 channel (4 bytes per pixel)
 	npy_intp dims[] = {frame->height, frame->width, 4 };
 
+	// this should be elsewhere, however, fails without it.
 	import_array();
-	//	PyArrayObject *array = (PyArrayObject*) PyArray_SimpleNew(3, dims, NPY_UINT8);
-	//memcpy(PyArray_DATA(array), frame->data, PyArray_NBYTES(array));
-	std::cout << "bpp: " << frame->bytes_per_pixel;
+
 	PyArrayObject *array = (PyArrayObject*) PyArray_SimpleNewFromData(3, 
 									  dims, 
 									  NPY_UINT8,
 									  frame->data);
 
+	return (PyObject*) array;
+}
+
+PyObject *py_Frame_getDepthData(PyObject *self, PyObject *args)
+{
+
+	PyObject *frameCapsule = NULL;
+	if(!PyArg_ParseTuple(args, "O", &frameCapsule))
+		return NULL;
+	Frame *frame = (Frame*) PyCapsule_GetPointer(frameCapsule, "Frame");
+
+	npy_intp dims[] = {frame->height, frame->width, 4};
+
+	import_array();
+
+	std::cout << "bpp: " << frame->bytes_per_pixel << std::endl;
+	PyArrayObject *array = (PyArrayObject*) PyArray_SimpleNewFromData(3, 
+									  dims, 
+									  NPY_UINT8,
+									  frame->data);
 	return (PyObject*) array;
 }

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -1,4 +1,5 @@
 #include "../pyfreenect2.hpp"
+#include <iostream>
 
 using libfreenect2::Frame;
 
@@ -21,12 +22,22 @@ PyObject *py_Frame_getWidth(PyObject *self, PyObject *args) {
 	return PyInt_FromSize_t(frame->width);
 }
 PyObject *py_Frame_getData(PyObject *self, PyObject *args) {
+
+
 	PyObject *frameCapsule = NULL;
 	if(!PyArg_ParseTuple(args, "O", &frameCapsule))
 		return NULL;
 	Frame *frame = (Frame*) PyCapsule_GetPointer(frameCapsule, "Frame");
-	npy_intp dims[] = { frame->height, frame->width, 3 };
-	PyArrayObject *array = (PyArrayObject*) PyArray_SimpleNew(3, dims, NPY_UINT8);
-	memcpy(PyArray_DATA(array), frame->data, PyArray_NBYTES(array));
+	npy_intp dims[] = {frame->height, frame->width, 4 };
+
+	import_array();
+	//	PyArrayObject *array = (PyArrayObject*) PyArray_SimpleNew(3, dims, NPY_UINT8);
+	//memcpy(PyArray_DATA(array), frame->data, PyArray_NBYTES(array));
+	std::cout << "bpp: " << frame->bytes_per_pixel;
+	PyArrayObject *array = (PyArrayObject*) PyArray_SimpleNewFromData(3, 
+									  dims, 
+									  NPY_UINT8,
+									  frame->data);
+
 	return (PyObject*) array;
 }

--- a/src/Freenect2Device.cpp
+++ b/src/Freenect2Device.cpp
@@ -1,4 +1,5 @@
 #include "../pyfreenect2.hpp"
+#include <iostream>
 
 using libfreenect2::Freenect2Device;
 using libfreenect2::FrameListener;
@@ -39,8 +40,14 @@ PyObject *py_Freenect2Device_setColorFrameListener(PyObject *self, PyObject *arg
 	if(!PyArg_ParseTuple(args, "OO", &deviceCapsule, &listenerCapsule))
 		return NULL;
 	Freenect2Device *device = (Freenect2Device*) PyCapsule_GetPointer(deviceCapsule, "Freenect2Device");
+
+	std::cout << "device in F2D.cpp: " << device << std::endl;
+	std::cout << "listenercapsule in F2D.cpp: " << listenerCapsule << std::endl;
 	Py_INCREF(listenerCapsule);
-	FrameListener *listener = (FrameListener*) PyCapsule_GetPointer(listenerCapsule, "FrameListener");
+	FrameListener *listener = (FrameListener*) PyCapsule_GetPointer(listenerCapsule, "SyncMultiFrameListener");
+
+	///// BOOO!!!
+	std::cout << "listener in F2D.cpp: " << listener << std::endl;
 	device->setColorFrameListener(listener);
 	Py_INCREF(Py_None);
 	return Py_None;
@@ -52,7 +59,7 @@ PyObject *py_Freenect2Device_setIrAndDepthFrameListener(PyObject *self, PyObject
 		return NULL;
 	Freenect2Device *device = (Freenect2Device*) PyCapsule_GetPointer(deviceCapsule, "Freenect2Device");
 	Py_INCREF(listenerCapsule);
-	FrameListener *listener = (FrameListener*) PyCapsule_GetPointer(listenerCapsule, "FrameListener");
+	FrameListener *listener = (FrameListener*) PyCapsule_GetPointer(listenerCapsule, "SyncMultiFrameListener");
 	device->setIrAndDepthFrameListener(listener);
 	Py_INCREF(Py_None);
 	return Py_None;

--- a/src/SyncMultiFrameListener.cpp
+++ b/src/SyncMultiFrameListener.cpp
@@ -1,17 +1,23 @@
 #include "../pyfreenect2.hpp"
+#include <iostream>
 
 using libfreenect2::FrameMap;
 using libfreenect2::SyncMultiFrameListener;
+
+void py_SyncMultiFrameListener_destroy(PyObject *listenerCapsule) {
+	delete ((SyncMultiFrameListener*) PyCapsule_GetPointer(listenerCapsule, 
+							       "SyncMultiFrameListener"));
+}
 
 PyObject *py_SyncMultiFrameListener_new(PyObject *self, PyObject *args) {
 	unsigned int frame_types = 0;
 	if(!PyArg_ParseTuple(args, "I", &frame_types))
 		return NULL;
 	SyncMultiFrameListener *listener = new SyncMultiFrameListener(frame_types);
-	return PyCapsule_New(listener, "SyncMultiFrameListener", py_SyncMultiFrameListener_destroy);
-}
-void py_SyncMultiFrameListener_destroy(PyObject *listenerCapsule) {
-	delete ((SyncMultiFrameListener*) PyCapsule_GetPointer(listenerCapsule, "SyncMultiFrameListener"));
+	std::cout << "listener in ext: " << listener << std::endl;
+	return PyCapsule_New(listener, 
+			     "SyncMultiFrameListener", 
+			     py_SyncMultiFrameListener_destroy);
 }
 
 PyObject *py_SyncMultiFrameListener_waitForNewFrame(PyObject *self, PyObject *args) {

--- a/test.py
+++ b/test.py
@@ -46,7 +46,7 @@ registration = pyfreenect2.Registration(kinect.ir_camera_params, kinect.color_ca
 cv2.startWindowThread()
 cv2.namedWindow("RGB")
 # cv2.namedWindow("IR")
-# cv2.namedWindow("Depth")
+cv2.namedWindow("Depth")
 
 # Main loop
 while not shutdown:
@@ -55,23 +55,19 @@ while not shutdown:
         print "got frame"
 	rgbFrame = frames.getFrame(pyfreenect2.Frame.COLOR)
 #	irFrame = frames.getFrame(pyfreenect2.Frame.IR)
-#	depthFrame = frames.getFrame(pyfreenect2.Frame.DEPTH)
+        depthFrame = frames.getFrame(pyfreenect2.Frame.DEPTH)
 
-        data = rgbFrame.getData()
+        rgb_frame = rgbFrame.getRGBData()
+        depth_frame = depthFrame.getDepthData()
+#        depth_frame = frames.getFrame(pyfreenect2.Frame.DEPTH).getData()
+
+        rgb_frame_resize = scipy.misc.imresize(rgb_frame, size = .5)
+        depth_frame_resize = scipy.misc.imresize(depth_frame, size = .5)
 
 	# TODO Display the frames w/ OpenCV
-	cv2.imshow("RGB", data)
+	cv2.imshow("RGB", rgb_frame_resize)
+	cv2.imshow("Depth", depth_frame_resize)
         cv2.waitKey(20)
-
-    # cv::imshow("ir", cv::Mat(ir->height, ir->width, CV_32FC1, ir->data) / 20000.0f);
-    # cv::imshow("depth", cv::Mat(depth->height, depth->width, CV_32FC1, depth->data) / 4500.0f);
-
-    # if (!registered) registered = new unsigned char[depth->height*depth->width*rgb->bytes_per_pixel];
-    # registration->apply(rgb,depth,registered);
-    # cv::imshow("registered", cv::Mat(depth->height, depth->width, CV_8UC3, registered));
-
-    # int key = cv::waitKey(1);
-    # protonect_shutdown = protonect_shutdown || (key > 0 && ((key & 0xFF) == 27)); // shutdown on escape
 
 kinect.stop()
 kinect.close()

--- a/test.py
+++ b/test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2
 
-import cv2
+import cv2, cv
+import scipy.misc
 import signal
 import pyfreenect2
 
@@ -22,6 +23,8 @@ signal.signal(signal.SIGINT, sigint_handler)
 frameListener = pyfreenect2.SyncMultiFrameListener(pyfreenect2.Frame.COLOR,
 	pyfreenect2.Frame.IR,
 	pyfreenect2.Frame.DEPTH)
+
+print frameListener
 kinect.setColorFrameListener(frameListener)
 kinect.setIrAndDepthFrameListener(frameListener)
 
@@ -33,7 +36,11 @@ print "Kinect serial: %s" % kinect.serial_number
 print "Kinect firmware: %s" % kinect.firmware_version
 
 # What's a registration?
+print kinect.ir_camera_params
+
 registration = pyfreenect2.Registration(kinect.ir_camera_params, kinect.color_camera_params)
+#registration = pyfreenect2.Registration(kinect.color_camera_params, kinect.ir_camera_params)
+#registration = pyfreenect2.Registration()
 
 # Initialize OpenCV stuff
 cv2.startWindowThread()
@@ -43,14 +50,19 @@ cv2.namedWindow("RGB")
 
 # Main loop
 while not shutdown:
+        print "waiting for frame"
 	frames = frameListener.waitForNewFrame()
+        print "got frame"
 	rgbFrame = frames.getFrame(pyfreenect2.Frame.COLOR)
-	irFrame = frames.getFrame(pyfreenect2.Frame.IR)
-	depthFrame = frames.getFrame(pyfreenect2.Frame.DEPTH)
+#	irFrame = frames.getFrame(pyfreenect2.Frame.IR)
+#	depthFrame = frames.getFrame(pyfreenect2.Frame.DEPTH)
+
+        data = rgbFrame.getData()
 
 	# TODO Display the frames w/ OpenCV
-	cv2.imshow("RGB", rgbFrame.getData())
-    # cv::imshow("rgb", cv::Mat(rgb->height, rgb->width, CV_8UC3, rgb->data));
+	cv2.imshow("RGB", data)
+        cv2.waitKey(20)
+
     # cv::imshow("ir", cv::Mat(ir->height, ir->width, CV_32FC1, ir->data) / 20000.0f);
     # cv::imshow("depth", cv::Mat(depth->height, depth->width, CV_32FC1, depth->data) / 4500.0f);
 

--- a/test.py
+++ b/test.py
@@ -50,9 +50,7 @@ cv2.namedWindow("Depth")
 
 # Main loop
 while not shutdown:
-        print "waiting for frame"
 	frames = frameListener.waitForNewFrame()
-        print "got frame"
 	rgbFrame = frames.getFrame(pyfreenect2.Frame.COLOR)
 #	irFrame = frames.getFrame(pyfreenect2.Frame.IR)
         depthFrame = frames.getFrame(pyfreenect2.Frame.DEPTH)

--- a/test.py
+++ b/test.py
@@ -56,14 +56,18 @@ while not shutdown:
         depthFrame = frames.getFrame(pyfreenect2.Frame.DEPTH)
 
         rgb_frame = rgbFrame.getRGBData()
+        bgr_frame = rgb_frame.copy()
+        bgr_frame[:,:,0] = rgb_frame[:,:,2]
+        bgr_frame[:,:,2] = rgb_frame[:,:,0]
+
         depth_frame = depthFrame.getDepthData()
 #        depth_frame = frames.getFrame(pyfreenect2.Frame.DEPTH).getData()
 
-        rgb_frame_resize = scipy.misc.imresize(rgb_frame, size = .5)
+        bgr_frame_resize = scipy.misc.imresize(bgr_frame, size = .5)
         depth_frame_resize = scipy.misc.imresize(depth_frame, size = .5)
 
 	# TODO Display the frames w/ OpenCV
-	cv2.imshow("RGB", rgb_frame_resize)
+	cv2.imshow("RGB", bgr_frame_resize)
 	cv2.imshow("Depth", depth_frame_resize)
         cv2.waitKey(20)
 


### PR DESCRIPTION
This PR fixed some critical bugs in the interface: some misnamings in the Freenect2Device.cpp wrapper were causing errors, and some conversion issues in Frame.cpp to extract the numpy arrays were addressed. `test.py` now works to view RGB and Depth frames, and a new class was added in `pyfreenect2.py` that simplifies all of the setup in `test.py`. A new example is in `examples/run.py`, which demonstrates using the new wrapper class to view streaming RGB images.

I commend the original author on their legwork getting this off the ground, hopefully others will find the fixes to the API useful. More remains to be done, but now the interface is fully usable for my purposes. 
